### PR TITLE
fix cask installer error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ rvm:
   - jruby-18mode
   - jruby-19mode
   - jruby-head
-  - rbx-18mode
-  - rbx-19mode
+  - rbx
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/lib/brewdler/cask_installer.rb
+++ b/lib/brewdler/cask_installer.rb
@@ -1,7 +1,7 @@
 module Brewdler
   class CaskInstaller
     def self.install(name)
-      if system 'brew cask info'
+      if system 'brew cask info ' + name
         `brew cask install #{name}`
       else
         raise "Unable to install #{name}. Homebrew-cask is not currently installed on your system"


### PR DESCRIPTION
Hello. 
I Fixed a bug that was not installed by an error when the installer executes the `brew cast info`.

Be installed on a result of this change, the name of the correct cask has been specified, the installation will be interrupted if the name of the cask that does not exist is specified.
My environment success all tests.(Mac OS X 10.8.2, ruby 2.0.0p247)

Please confirm.
Thank you.